### PR TITLE
feat: add testnet network

### DIFF
--- a/.changeset/olive-pots-hug.md
+++ b/.changeset/olive-pots-hug.md
@@ -1,0 +1,5 @@
+---
+"@fuels/streams": patch
+---
+
+Add support for testnet network

--- a/.github/actions/setup-bun/action.yaml
+++ b/.github/actions/setup-bun/action.yaml
@@ -5,7 +5,7 @@ inputs:
   bun-version:
     description: "Bun version to install"
     required: false
-    default: "1.2.2"
+    default: "1.2.14"
 
 runs:
   using: composite
@@ -14,6 +14,7 @@ runs:
       name: Install Bun
       with:
         bun-version: ${{ inputs.bun-version }}
+        cache: true
 
     - name: Install dependencies
       shell: bash

--- a/packages/fuel-streams/src/ws/networks.ts
+++ b/packages/fuel-streams/src/ws/networks.ts
@@ -3,8 +3,8 @@ import { FuelNetwork } from './types';
 export function getNetworkFromEnv(): FuelNetwork {
   const network = process.env.NETWORK;
   switch (network) {
-    // case 'testnet':
-    //   return FuelNetwork.Testnet;
+    case 'testnet':
+      return FuelNetwork.Testnet;
     case 'mainnet':
       return FuelNetwork.Mainnet;
     case 'staging':
@@ -20,8 +20,8 @@ export function getWsUrl(network: FuelNetwork): URL {
       return new URL('ws://0.0.0.0:9003');
     case FuelNetwork.Staging:
       return new URL('wss://stream-staging.fuel.network');
-    // case FuelNetwork.Testnet:
-    //   return new URL('wss://stream-testnet.fuel.network');
+    case FuelNetwork.Testnet:
+      return new URL('wss://stream-testnet.fuel.network');
     case FuelNetwork.Mainnet:
       return new URL('wss://stream-mainnet.fuel.network');
   }

--- a/packages/fuel-streams/src/ws/types.ts
+++ b/packages/fuel-streams/src/ws/types.ts
@@ -4,6 +4,7 @@ export enum FuelNetwork {
   Local = 'local',
   Staging = 'staging',
   Mainnet = 'mainnet',
+  Testnet = 'testnet',
 }
 
 export type SubjectPayload = {

--- a/packages/simple-app/src/components/header.tsx
+++ b/packages/simple-app/src/components/header.tsx
@@ -38,7 +38,7 @@ export function Header() {
           <a
             target="_blank"
             rel="noreferrer"
-            href="https://api-rest-mainnet.fuel.network/swagger-ui/"
+            href={`https://api-rest-${network}.fuel.network/swagger-ui/`}
             className="flex items-center justify-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors"
           >
             Rest API
@@ -70,6 +70,9 @@ export function Header() {
             <SelectContent>
               <SelectItem value="mainnet" aria-label="Fuel Ignition">
                 Fuel Ignition
+              </SelectItem>
+              <SelectItem value="testnet" aria-label="Fuel Testnet">
+                Fuel Testnet
               </SelectItem>
               {isDev && (
                 <SelectItem value="local" aria-label="Fuel Local">

--- a/packages/simple-app/src/index.css
+++ b/packages/simple-app/src/index.css
@@ -96,3 +96,10 @@
     @apply bg-background text-foreground;
   }
 }
+
+#root {
+  overflow-y: hidden;
+  box-sizing: border-box;
+  height: 100vh;
+  width: 100vw;
+}


### PR DESCRIPTION
This pull request introduces support for the `testnet` network in the `fuel-streams` package and updates the `simple-app` package to accommodate this addition. Additionally, it includes a minor CSS enhancement for the root element. Below are the key changes grouped by theme:

### Support for `testnet` in `fuel-streams`:

* [`packages/fuel-streams/src/ws/types.ts`](diffhunk://#diff-b788a4ff85af0ab5282a1bb3e7c85bd6a747bb970fda5ccb4fe49aad4bc54f36R7): Added `Testnet` as a new value in the `FuelNetwork` enum.
* `packages/fuel-streams/src/ws/networks.ts`: 
  - Enabled the `testnet` case in `getNetworkFromEnv` to return `FuelNetwork.Testnet`.
  - Updated `getWsUrl` to handle the `Testnet` network and return its corresponding WebSocket URL.

### Updates to `simple-app`:

* `packages/simple-app/src/components/header.tsx`: 
  - Updated the `Rest API` link to dynamically use the selected network.
  - Added `Fuel Testnet` as a selectable network option in the dropdown menu.

### CSS Enhancement:

* [`packages/simple-app/src/index.css`](diffhunk://#diff-a4dc1cd1109a26921cb5651676d9a6ce4799c6519f63dc1e07acbc5ce2d94848R99-R105): Added styles for the `#root` element to ensure proper layout handling, including full viewport dimensions and hidden overflow.